### PR TITLE
Remove beta key from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,9 @@
   plugins:
     swiftlint:
       enabled: true
-      channel: beta
   ```
 3. You're ready to analyze! Browse into your project's folder and run `codeclimate analyze`.
 
 ### SwiftLint Config
 
-`codeclimate-swiftlint` works with your existing `.swiftlint.yml` file. 
+`codeclimate-swiftlint` works with your existing `.swiftlint.yml` file.


### PR DESCRIPTION
- This hasn't been in beta for a few months so removing the `beta` key from the example config